### PR TITLE
Fixes an issue with *.missing_pgx_var.vcf file

### DIFF
--- a/src/scripts/preprocessor/vcf_preprocess_utilities.py
+++ b/src/scripts/preprocessor/vcf_preprocess_utilities.py
@@ -623,7 +623,7 @@ def filter_pgx_variants(bcftools_path, tabix_path, bgzip_path, input_vcf, ref_se
                         line = line.rstrip('\n')
                         fields = line.split('\t')
                         fields[-1] = 'Missing'
-                        out_f.write('\t'.join(fields))
+                        out_f.write('\t'.join(fields) + '\n')
                     else:
                         break
             # output positions that were not detected in the input VCF


### PR DESCRIPTION
Fixes an issue where no new-line is printed after the VCF header in the *.missing_pgx_var.vcf