### PR TITLE
fix(docker): sanitize ownership of reference FASTA files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir /pharmcat
 WORKDIR /pharmcat
 # download fasta files
 RUN wget https://zenodo.org/record/7288118/files/GRCh38_reference_fasta.tar && \
-    tar -xf GRCh38_reference_fasta.tar && \
+    tar -xf GRCh38_reference_fasta.tar --no-same-owner && \
     rm -f GRCh38_reference_fasta.tar
 
 


### PR DESCRIPTION
The content in https://zenodo.org/record/7288118/files/GRCh38_reference_fasta.tar has an UID of 197609 and GID of 197121.

When files are extracted by a superuser (root here), `tar` tries to restore that ownership by default. And ownership with such large UID or GID causes problem in rootless containers. (See https://github.com/containers/buildah/issues/1702)

Without this patch, most users running rootless containers won't be able to pull the Docker image successfully and are likely to encounter following error during the process.

```
Error: writing blob: adding layer with blob "sha256:ac117c39ea159f0dd704f2473d529e0157998921cf83dc2bef8190734c27a77e": Error processing tar file(exit status 1): potentially insufficient UIDs or GIDs available in user namespace (requested 197609:197121 for /pharmcat/reference.fna.bgz): Check /etc/subuid and /etc/subgid: lchown /pharmcat/reference.fna.bgz: invalid argument
```