### PR TITLE
docs: escape asterisks in star alleles

### DIFF
--- a/docs/Disclaimers.md
+++ b/docs/Disclaimers.md
@@ -155,7 +155,7 @@ All content is sourced from the [CPIC database](https://github.com/cpicpgx/cpic-
    refer to the PharmCAT [outside calls documentation](https://pharmcat.org/using/Outside-Call-Format/).
 
 2. CPIC has assigned function to the following CYP2D6 CNV alleles: \*1x2, \*1x≥3, \*2x2, \*2x≥3, \*3x2, \*4x2, \*4x≥3,
-   \*6x2, \*9x2, \*10x2, \*17x2, \*29x2, \*35x2, \*36x2, \*41x2, \*41x3, \*43x2, \*45x2, *146x2. These alleles are part
+   \*6x2, \*9x2, \*10x2, \*17x2, \*29x2, \*35x2, \*36x2, \*41x2, \*41x3, \*43x2, \*45x2, \*146x2. These alleles are part
    of the CPIC diplotype to phenotype translation and can be connected to recommendations. Other CNV notations from
    outside calls need to be mapped accordingly. 
 

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -107,11 +107,11 @@ Indeterminate is a standardized CPIC phenotype term assigned to genotypes contai
 
 Please review the latest [CPIC SOP for assigning allele function](https://cpicpgx.org/resources/cpic-draft-allele-function-sop/) for further details or any updates on the definitions.
 
-### How to understand "_reference_" or "_*1_"?
+### How to understand "Reference" or "\*1"?
 
-You will see "Reference" (for genes like _DPYD_, _RYR1_, _CACNA1S_, _CFTR_, etc.) or "*1" (for genes like _CYP2B6_, _CYP2C9_, etc.). _Reference_ or _*1_ indicate an absence of alternative genetic alleles at the PharmCAT interrogated genetic positions. They are assigned by default when no alternative variants are found at the queried positions. They do not suggest a lack of genetic variation at every position in the gene and should not be mistaken to mean an exact match to the entire reference sequence for the gene.
+You will see "Reference" (for genes like _DPYD_, _RYR1_, _CACNA1S_, _CFTR_, etc.) or "\*1" (for genes like _CYP2B6_, _CYP2C9_, etc.). "Reference" or "\*1" indicate an absence of alternative genetic alleles at the PharmCAT interrogated genetic positions. They are assigned by default when no alternative variants are found at the queried positions. They do not suggest a lack of genetic variation at every position in the gene and should not be mistaken to mean an exact match to the entire reference sequence for the gene.
 
-For the gene _CFTR_, "_Reference_" in the PharmCAT report corresponds to "_ivacaftor non-reponsive CFTR sequnence_" in the CPIC guideline.
+For the gene _CFTR_, "Reference" in the PharmCAT report corresponds to "ivacaftor non-reponsive CFTR sequnence" in the CPIC guideline.
 
 
 ### How to render PharmCAT outputs into a tabular-formatted file
@@ -136,7 +136,7 @@ Some PGx allele-defining positions are multiallelic and can harbor other genetic
 ### Can PharmCAT call _CYP2D6_?
 If you have access to whole genome sequencing (WGS) CRAM/BAM files, we strongly discourage calling CYP2D6 using PharmCAT. Please refer to our documentation about [calling CYP2D6](/using/Calling-CYP2D6).
 
-Starting with v2.0, PharmCAT provides a research mode for calling CYP2D6. PharmCAT is designed to take VCF as input which is NOT a desirable file format for calling CYP2D6 alleles. This research mode for CYP2D6 calls alleles using ONLY SNPs and INDELs that are available in VCF files. Please note that this approach has many caveats. VCF can't handle structural variation (SV) and copy number variation (CNV) which are essential for calling CYP2D6 alleles, especially CNVs for ultrarapid metabolizers. VCF format cannot correctly reflect whole gene deletion (*5), which will lead to erroneous calls and beyond the capability of PharmCAT. CYP2D6 calls made from VCFs should not be used for clinical purposes. This research mode should be used at your own risk.
+Starting with v2.0, PharmCAT provides a research mode for calling CYP2D6. PharmCAT is designed to take VCF as input which is NOT a desirable file format for calling CYP2D6 alleles. This research mode for CYP2D6 calls alleles using ONLY SNPs and INDELs that are available in VCF files. Please note that this approach has many caveats. VCF can't handle structural variation (SV) and copy number variation (CNV) which are essential for calling CYP2D6 alleles, especially CNVs for ultrarapid metabolizers. VCF format cannot correctly reflect whole gene deletion (\*5), which will lead to erroneous calls and beyond the capability of PharmCAT. CYP2D6 calls made from VCFs should not be used for clinical purposes. This research mode should be used at your own risk.
 
 
 ### _G6PD_ for samples with only one chrX

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -49,7 +49,7 @@ data. This data is visible in an HTML report and also in a JSON file for machine
 
 # Example 2 - Some Non-Reference Alleles
 
-This is a collection of example files with CYP2C19 *2/*2 and CYP2B6 *1/*6 diplotypes. One input VCF file that contains 
+This is a collection of example files with CYP2C19 \*2/\*2 and CYP2B6 \*1/\*6 diplotypes. One input VCF file that contains
 the source variant data and the corresponding output files that would result from running that input file.
 
 ## Input VCF

--- a/docs/methods/NamedAlleleMatcher-101.md
+++ b/docs/methods/NamedAlleleMatcher-101.md
@@ -9,7 +9,7 @@ nav_order: 4
 The basic process:
 
 1. Read in all named allele definitions from the gene definition table.
-   Each gene has a reference allele defined by the first definition row in the table (eg. _*1_).  By default, any non-reference named allele that does not contain a base call for a given position (ie. blank spots in the definition table) will default to the reference row's base call.
+   Each gene has a reference allele defined by the first definition row in the table (eg. \*1).  By default, any non-reference named allele that does not contain a base call for a given position (ie. blank spots in the definition table) will default to the reference row's base call.
 2. Read in sample data (VCF file), ignoring positions that are not used in the gene definition tables.
 3. For each gene:
     1. If data is unphased, generate all possible combinations of genotypes for the positions of interest.
@@ -28,12 +28,12 @@ Take a look at this sample gene definition table:
 
 |     | rs1 | rs2 | rs3 | rs4 | rs5 | score |
 | --- | --- | --- | --- | --- | --- | ----- |
-| *1  | C   | C   | T   | G   | A   | 5     |
-| *2  | T   | T   |     | A   |     | 3     |
+| \*1 | C   | C   | T   | G   | A   | 5     |
+| \*2 | T   | T   |     | A   |     | 3     |
 
-Since the gene definition table contains 5 positions, the reference allele, _*1_, gets a score of 5 while _*2_ only has 3 positions defined and gets a score of 3. <sup>[3](#notes)</sup>
+Since the gene definition table contains 5 positions, the reference allele, \*1, gets a score of 5 while \*2 only has 3 positions defined and gets a score of 3. <sup>[3](#notes)</sup>
 
-A diplotype's score is the combined score of its component named alleles.  A _*1_/_*2_ from the example above would have a score of 8.
+A diplotype's score is the combined score of its component named alleles.  A \*1/\*2 from the example above would have a score of 8.
 
 
 ## Missing Positions
@@ -49,11 +49,11 @@ Using the following gene definition table:
 
 |     | rs1 | rs2 | rs3 | rs4 | rs5 | score |
 | --- | --- | --- | --- | --- | --- | ----- |
-| *1  | C   | C   | T   | G   | A   | 5     |
-| *2  | T   |     |     | A   |     | 2     |
-| *3  |     |     |     | A   |     | 1     |
-| *4  |     | T   |     |     |     | 1     |
-| *5  | T   |     |     |     |     | 1     |
+| \*1 | C   | C   | T   | G   | A   | 5     |
+| \*2 | T   |     |     | A   |     | 2     |
+| \*3 |     |     |     | A   |     | 1     |
+| \*4 |     | T   |     |     |     | 1     |
+| \*5 | T   |     |     |     |     | 1     |
 
 And the following (unphased) sample data:
 
@@ -61,18 +61,18 @@ And the following (unphased) sample data:
 | --- | --- | --- | --- | --- |
 | C/T | C/C | T/T | A/G | A/A |
 
-The potential permutations of those genotypes will match _*1_, _*2_, _*3_ and _*5_.
+The potential permutations of those genotypes will match \*1, \*2, \*3 and \*5.
 
 From that, plausible diplotypes are:
 
 | Diplotype | Score     |
 | --------- | --------- |
-| *1/*2     | 5 + 2 = 7 |
-| *3/*5     | 1 + 1 = 2 |
+| \*1/\*2   | 5 + 2 = 7 |
+| \*3/\*5   | 1 + 1 = 2 |
 
-Which results in _*1_/_*2_ being returned.
+Which results in \*1/\*2 being returned.
 
-Note that _*1_/_*3_ is not a plausible diplotype because one chromosome must have a `C` and the other must have a `T` at position rs1.  They can't both be `C`.  Similarly, _*2_/_*3_ is not a plausible diplotype either because it cannot be homozygous at rs4.
+Note that \*1/\*3 is not a plausible diplotype because one chromosome must have a `C` and the other must have a `T` at position rs1.  They can't both be `C`.  Similarly, \*2/\*3 is not a plausible diplotype either because it cannot be homozygous at rs4.
 
 
 #### Missing rs5
@@ -87,8 +87,8 @@ The results would be the same, except the scores would be different:
 
 | Diplotype | Score     |
 | --------- | --------- |
-| *1/*2     | 4 + 2 = 6 |
-| *3/*5     | 1 + 1 = 2 |
+| \*1/\*2   | 4 + 2 = 6 |
+| \*3/\*5   | 1 + 1 = 2 |
 
 
 #### Missing rs1
@@ -103,12 +103,12 @@ Then the results would be different:
 
 | Diplotype | Score     |
 | --------- | --------- |
-| *1/*2     | 4 + 1 = 5 |
-| *1/*3     | 4 + 1 = 5 |
+| \*1/\*2   | 4 + 1 = 5 |
+| \*1/\*3   | 4 + 1 = 5 |
 
-As such, _*1_/_*2_ and _*1_/_*3_ would be returned.
+As such, \*1/\*2 and \*1/\*3 would be returned.
 
-Note that *5 could never be matched in this scenario because it's definining allele is missing.
+Note that \*5 could never be matched in this scenario because it's definining allele is missing.
 
 
 ### Notes

--- a/docs/methods/NamedAlleleMatcher-201.md
+++ b/docs/methods/NamedAlleleMatcher-201.md
@@ -19,19 +19,19 @@ Example:
 
 |     | rs1 | rs2 | rs3 | rs4 | rs5 | score |
 | --- | --- | --- | --- | --- | --- | ----- |
-| *1  | C   | C   | T   | G   | A   | 5     |
-| *2  | T   | T   |     | A   |     | 3     |
+| \*1 | C   | C   | T   | G   | A   | 5     |
+| \*2 | T   | T   |     | A   |     | 3     |
 
 The default named allele definitions are designed to assume that missing alleles are the same as the reference named 
 allele, which is defined as the first named allele in the definition file.
 
 It is, however, possible to increase the score of a named allele by specifying the reference allele.  For example, this
-gene definition table is effectively identical to the one above, but _*2_ has a different score.
+gene definition table is effectively identical to the one above, but `*2` has a different score.
 
 |     | rs1 | rs2 | rs3 | rs4 | rs5 | score |
 | --- | --- | --- | --- | --- | --- | ----- |
-| *1  | C   | C   | T   | G   | A   | 5     |
-| *2  | T   | T   | T   | A   | A   | 5     |
+| \*1 | C   | C   | T   | G   | A   | 5     |
+| \*2 | T   | T   | T   | A   | A   | 5     |
 
 
 
@@ -74,7 +74,7 @@ PharmCAT's syntax for combination calls uses square brackets to reflect that it 
 distinguish it from gene duplications (e.g. tandem arrangements like CYP2D6 `*36+*10`).
 
 A partial allele is when a sample matches all the (core) variants of a defined allele but also has additional variants.
-For example, CYP2C19 `"*2/[*17 + g.94781859G>A]"`.  In the case where a partial call occurs off the reference allele,
+For example, CYP2C19 `*2/[*17 + g.94781859G>A]`.  In the case where a partial call occurs off the reference allele,
 only the positions are listed (e.g. `*2/g.94781859G>A`).
 
 When asked to find combination and partial alleles, the `Named Allele Matcher` will only attempt to do so if no viable 
@@ -98,7 +98,7 @@ phased or the unphased data only has 2 possible sequence combinations.
 
 ### Scoring
 
-Because PharmCAT scores on the number of matched positions in the definitions, the reference named allele (usually *1) 
+Because PharmCAT scores on the number of matched positions in the definitions, the reference named allele (usually \*1)
 will get the highest score. As such, scoring is biased towards grouping combinations together.  For example, CYP2B6 
 `*1/[*5 + *9 + *23]` will be the call with the highest score but permutations such as `*5/[*9 + *23]`, `*9/[*5 + *23]`,
 `*23/[*5 + *9]` are also possible.

--- a/docs/using/Calling-CYP2D6.md
+++ b/docs/using/Calling-CYP2D6.md
@@ -28,12 +28,12 @@ For demonstration purposes, we are using [StellarPGx](https://github.com/SBIMB/S
 
 | Sample | WES | Low-Cov WGS | 30x WGS | GeT-RM |
 | ------ | --- | ----------- | ------- | ------ |
-| [HG00436](https://www.internationalgenome.org/data-portal/sample/HG00436) | No_call | No_call | *71/*2x2 | *2x2/*71 |
-| [HG01086](https://www.internationalgenome.org/data-portal/sample/HG01086) | *1/*1x2 | No_call | *1/*31 | *1/*31 |
-| [HG01190](https://www.internationalgenome.org/data-portal/sample/HG01190) | *1/*1 | *5/*1 | *5/*68+*4 | *68+*4/*5 |
-| [NA07048](https://www.internationalgenome.org/data-portal/sample/NA07048) | No_call | *1/*1 | *139/*4 | *1/*4 |
-| [NA18545](https://www.internationalgenome.org/data-portal/sample/NA18545) | *34/*34x7 | *1/*1x5 | *36+*10/*36+*10 | *5/*36x2+*10x2 |
-| [NA21105](https://www.internationalgenome.org/data-portal/sample/NA21105) | No_call | *34/*34 | *111/*3 | *3/*111 |
+| [HG00436](https://www.internationalgenome.org/data-portal/sample/HG00436) | No_call | No_call | \*71/\*2x2 | \*2x2/\*71 |
+| [HG01086](https://www.internationalgenome.org/data-portal/sample/HG01086) | \*1/\*1x2 | No_call | \*1/\*31 | \*1/\*31 |
+| [HG01190](https://www.internationalgenome.org/data-portal/sample/HG01190) | \*1/\*1 | \*5/\*1 | \*5/\*68+\*4 | \*68+\*4/\*5 |
+| [NA07048](https://www.internationalgenome.org/data-portal/sample/NA07048) | No_call | \*1/\*1 | \*139/\*4 | \*1/\*4 |
+| [NA18545](https://www.internationalgenome.org/data-portal/sample/NA18545) | \*34/\*34x7 | \*1/\*1x5 | \*36+\*10/\*36+\*10 | \*5/\*36x2+\*10x2 |
+| [NA21105](https://www.internationalgenome.org/data-portal/sample/NA21105) | No_call | \*34/\*34 | \*111/\*3 | \*3/\*111 |
 
 There is drastic variation in the calls produced by the three sequencing technologies. In many cases, the WES or low-coverage WGS input resulted in a "no call" result. In some samples, improbably high copy numbers and calls that varied greatly from the GeT-RM calls were produced. The 30x WGS produced identical or equivalent results most of the time, and when it deviated the differences were relatively minor. In conclusion, we do not recommend the use WES or low-coverage WGS for calling CYP2D6 for both research and clinical purposes.
 

--- a/docs/using/Calling-HLA.md
+++ b/docs/using/Calling-HLA.md
@@ -22,10 +22,10 @@ We tested imputation accuracy using 258 in house samples for which we had target
 
 | HLA Allele   | Sequence | Imputed |
 |--------------|----------|---------|
-| HLA-A*31:01 | 25       | 14      |
-| HLA-B*15:02 | 3        | 2       |
-| HLA-B*57:01 | 13       | 13      |
-| HLA-B*58:01 | 8        | 7       |
+| HLA-A\*31:01 | 25       | 14      |
+| HLA-B\*15:02 | 3        | 2       |
+| HLA-B\*57:01 | 13       | 13      |
+| HLA-B\*58:01 | 8        | 7       |
 
 Our results indicate that HLA B allele imputation was more accurate than the single HLA-A allele tested. While imputation is possible from a VCF, **we do NOT recommend imputing HLA from a VCF** as there are many factors that contribute to inaccuracy (e.g., marker density, an appropriate reference panel, etc.). [Although the methods and reference panels](https://doi.org/10.1038/tpj.2017.7) have drastically improved over the past few years, we still have reservations based on our own internal testing of the accuracy of allele typing. Instead, we recommend that you call HLA directly from either whole exome or whole genome data.
 
@@ -84,10 +84,10 @@ Note, of the 203 samples tested, Optitype misassigned an HLA to 3 of the samples
 
 | HLA Allele   | OPTITYPE CALLS | 1KG OFFICIAL CALLS |
 |--------------|----------------|--------------------|
-| HLA-A*31:01 | 47             | 48                 |
-| HLA-B*15:02 | 39             | 39                 |
-| HLA-B*57:01 | 54             | 54                 |
-| HLA-B*58:01 | 67             | 69                 |
+| HLA-A\*31:01 | 47             | 48                 |
+| HLA-B\*15:02 | 39             | 39                 |
+| HLA-B\*57:01 | 54             | 54                 |
+| HLA-B\*58:01 | 67             | 69                 |
 
 Regardless of whether it is a single sample per sheet or multi-sample per sample sheet, Optitype will generate individual files for each sample. Nextflow It will generate a plot showing the overall coverage of the allele and a TSV (tab-separated values) file with the HLA allele calls. It is always a good idea to check and ensure you had good coverage across the HLA region.
 

--- a/docs/using/Outside-Call-Format.md
+++ b/docs/using/Outside-Call-Format.md
@@ -73,7 +73,7 @@ We rely on string matching to match outside calls to recommendations.
 
 Consult the [Phenotypes List](/Phenotypes-List) for a complete list of named alleles, phenotypes and activity scores.
 
-_Do not_ prefix allele names with the gene symbol in the second field (e.g. CYP2C9*1/CYP2C9*3). The gene is specified in
+_Do not_ prefix allele names with the gene symbol in the second field (e.g. `CYP2C9*1/CYP2C9*3`). The gene is specified in
 the first field so repeating it in second field is not necessary.
 
 If there is an outside call for a gene that also has data from the VCF, the outside call will trump the VCF data.

--- a/docs/using/Research-Mode.md
+++ b/docs/using/Research-Mode.md
@@ -48,7 +48,7 @@ distinguish it from gene duplications (e.g. tandem arrangements like CYP2D6 `*36
 
 A partial allele is when a sample matches all the (core) variants of a defined allele but also has additional variants.  For example, CYP2C19 `*2/[*17 + g.94781859G>A]`.  In the case where a partial call occurs off the reference allele, only the positions are listed (e.g. `*2/g.94781859G>A`).  A partial off the reference allele will only be called if the data is phased, or the unphased data only has 2 possible sequence combinations.
 
-Note that PharmCAT only provides the match(es) with the highest score by default. Because PharmCAT scores on the number of matched positions in the definitions, the reference named allele (usually *1) will get the highest score. As such, scoring is biased towards grouping combinations together.  For example, CYP2B6 `*1/[*5 + *9 + *23]` will be the call with the highest score but permutations such as `*5/[*9 + *23]`, `*9/[*5 + *23]`, `*23/[*5 + *9]` are also valid.
+Note that PharmCAT only provides the match(es) with the highest score by default. Because PharmCAT scores on the number of matched positions in the definitions, the reference named allele (usually \*1) will get the highest score. As such, scoring is biased towards grouping combinations together.  For example, CYP2B6 `*1/[*5 + *9 + *23]` will be the call with the highest score but permutations such as `*5/[*9 + *23]`, `*9/[*5 + *23]`, `*23/[*5 + *9]` are also valid.
 
 For more details on combinations and partial alleles, please see [NamedAlleleMatcher 201](/methods/NamedAlleleMatcher-201#combinations-and-partial-alleles).
 


### PR DESCRIPTION
Asterisks, when in pairs, will be interpreted as italic syntax.

Escape asterisk in star allele with backslash or wrap the whole allele with backticks.