### PR TITLE
docs: fix navigation menu

### DIFF
--- a/docs/methods/Gene-Definition-Exceptions.md
+++ b/docs/methods/Gene-Definition-Exceptions.md
@@ -1,5 +1,5 @@
 ---
-parent: Methods
+parent: How It Works
 title: Gene Definition Exceptions
 permalink: methods/Gene-Definition-Exceptions/
 nav_order: 4

--- a/docs/methods/Matching-Recommendations.md
+++ b/docs/methods/Matching-Recommendations.md
@@ -1,5 +1,5 @@
 ---
-parent: Methods
+parent: How It Works
 title: Matching Recommendations
 permalink: methods/Matching-Recommendations/
 nav_order: 5

--- a/docs/methods/NamedAlleleMatcher-101.md
+++ b/docs/methods/NamedAlleleMatcher-101.md
@@ -1,5 +1,5 @@
 ---
-parent: Methods
+parent: How It Works
 title: Named Allele Matcher 101
 permalink: methods/NamedAlleleMatcher-101/
 nav_order: 2

--- a/docs/methods/NamedAlleleMatcher-201.md
+++ b/docs/methods/NamedAlleleMatcher-201.md
@@ -1,5 +1,5 @@
 ---
-parent: Methods
+parent: How It Works
 title: Named Allele Matcher 201
 permalink: methods/NamedAlleleMatcher-201/
 nav_order: 3


### PR DESCRIPTION
After an index title change, some pages are now missing in navigation menu.

This patch updates parent attributes accordingly so these subtopics get displayed again.