### PR TITLE
fix: correct _is_phased() early return and prevent KeyError on duplicate variants

### DIFF
--- a/preprocessor/pcat/utilities.py
+++ b/preprocessor/pcat/utilities.py
@@ -879,14 +879,15 @@ def normalize_vcf(reference_genome: Path, vcf_file: Path, output_dir: Path, outp
 def _is_phased(gt_field) -> bool | None:
     """
     Determines the phasing status of a position.
-    If any GT fields have a '/', this means at least one sample is unphased.
+    Returns False if any sample is unphased (contains '/'),
+    True if all samples are phased, None if gt_field is empty.
     """
+    if not gt_field:
+        return None
     for x in gt_field:
         if '/' in x:
             return False
-        else:
-            return True
-    return None
+    return True
 
 
 def _is_haploid(gt_field) -> bool:
@@ -1094,7 +1095,7 @@ def extract_pgx_variants(pharmcat_positions: Path, reference_fasta: Path, vcf_fi
                                 out_f.write('\t'.join(fields) + '\n')
                                 # elimination: remove the dictionary item so that the variant won't be matched again
                                 if input_chr_pos in ref_pos_dynamic:
-                                    ref_pos_dynamic[input_chr_pos].pop(input_ref_alt)
+                                    ref_pos_dynamic[input_chr_pos].pop(input_ref_alt, None)
                                     # remove a position if all of its alts are present in the input
                                     if ref_pos_dynamic[input_chr_pos] == {}:
                                         del ref_pos_dynamic[input_chr_pos]
@@ -1117,7 +1118,7 @@ def extract_pgx_variants(pharmcat_positions: Path, reference_fasta: Path, vcf_fi
 
                                         # for hom ref SNPs, remove the position from the dict for record
                                         if input_chr_pos in ref_pos_dynamic:
-                                            ref_pos_dynamic[input_chr_pos].pop((ref_alleles[i], alt_alleles[i]))
+                                            ref_pos_dynamic[input_chr_pos].pop((ref_alleles[i], alt_alleles[i]), None)
                                             # remove a position if all of its alts are present in the input
                                             if ref_pos_dynamic[input_chr_pos] == {}:
                                                 del ref_pos_dynamic[input_chr_pos]


### PR DESCRIPTION
## Summary

Two bugs fixed in `preprocessor/pcat/utilities.py`:

### 1. `_is_phased()` returns on first sample (line ~879)

The function checks phasing status but returns immediately on the first GT field, never examining subsequent samples.

```python
# Before (bug): returns on first sample
for x in gt_field:
    if '/' in x:
        return False
    else:
        return True  # exits loop on first iteration!

# After (fix): checks all samples
for x in gt_field:
    if '/' in x:
        return False
return True  # only returns True after checking ALL samples
```

**Impact:** Multi-sample VCFs may have incorrect phasing determination, leading to wrong star allele calls.

### 2. KeyError on duplicate normalized variants (fixes #222)

`ref_pos_dynamic[pos].pop(ref_alt)` crashes when multiple input variants normalize to the same coordinate/allele pair. Changed to `.pop(key, None)` to handle collisions gracefully.

## Test plan
- Run existing preprocessing tests: `cd preprocessor && pytest tests/`
- Test with multi-sample phased VCF to verify phasing preserved