### PR TITLE
Add a local no-Logback packaging target

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ All technical requirements and documentation are available on [PharmCAT.org](htt
 PharmCAT is managed at Stanford University & University of Pennsylvania (NHGRI U24HG013077).
 
 
+## Building without Logback
+
+Applications that provide their own [SLF4J](https://www.slf4j.org/) implementation can build an executable PharmCAT
+JAR without Logback:
+
+```console
+./gradlew noLogbackJar
+```
+
+The task writes `build/libs/pharmcat-<version>-no-logback.jar`. The JAR includes PharmCAT's other runtime dependencies
+but excludes Logback and `logback.xml`; the consuming application must provide a compatible SLF4J implementation and
+logging configuration.
+
+
 ## Contact
 
 For technical questions or bug reports, [file an issue](https://github.com/PharmGKB/PharmCAT/issues).

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   id 'java'
   id 'application'
@@ -124,6 +126,7 @@ tasks.withType(JavaExec).configureEach {
 }
 
 tasks.withType(Test).configureEach {
+  dependsOn 'jar', 'shadowJar', 'noLogbackJar'
   minHeapSize = "512m"
   maxHeapSize = "4096m"
   // hide restricted method warnings
@@ -134,6 +137,12 @@ tasks.withType(Test).configureEach {
     events 'failed', 'standard_error'
     exceptionFormat = 'full'
     showStackTraces = true
+  }
+
+  doFirst {
+    systemProperty 'pharmcat.thinJar', tasks.named('jar').get().archiveFile.get().asFile.absolutePath
+    systemProperty 'pharmcat.shadowJar', tasks.named('shadowJar').get().archiveFile.get().asFile.absolutePath
+    systemProperty 'pharmcat.noLogbackJar', tasks.named('noLogbackJar').get().archiveFile.get().asFile.absolutePath
   }
 
   // always generate reports after tests are run
@@ -181,6 +190,26 @@ shadowJar {
   }
   archiveBaseName = project.ext.archiveBaseName
   archiveFileName = project.ext.archiveBaseName + "-" + project.ext.version + "-all.jar";
+}
+
+tasks.register('noLogbackJar', ShadowJar) {
+  group = 'build'
+  description = 'Builds an executable jar without Logback so consumers can supply an SLF4J provider.'
+  from sourceSets.main.output
+  configurations = [project.configurations.runtimeClasspath]
+  dependencies {
+    exclude(dependency('ch.qos.logback:logback-classic'))
+    exclude(dependency('ch.qos.logback:logback-core'))
+  }
+  exclude 'logback.xml'
+  manifest {
+    attributes 'Automatic-Module-Name': project.ext.moduleName
+    attributes 'Implementation-Title': project.name
+    attributes 'Implementation-Version': project.ext.version
+    attributes 'Main-Class': project.ext.mainClassName
+  }
+  archiveBaseName = project.ext.archiveBaseName
+  archiveFileName = project.ext.archiveBaseName + "-" + project.ext.version + "-no-logback.jar";
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/src/test/java/org/pharmgkb/pharmcat/DistributionArchiveTest.java
+++ b/src/test/java/org/pharmgkb/pharmcat/DistributionArchiveTest.java
@@ -1,0 +1,64 @@
+package org.pharmgkb.pharmcat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DistributionArchiveTest {
+
+  @Test
+  void thinArchiveKeepsExistingContents() throws IOException {
+    Set<String> entries = readEntries("pharmcat.thinJar");
+
+    assertTrue(entries.contains("org/pharmgkb/pharmcat/PharmCAT.class"));
+    assertFalse(entries.stream().anyMatch(name -> name.startsWith("ch/qos/logback/")));
+    assertFalse(entries.stream().anyMatch(name -> name.startsWith("org/slf4j/")));
+    assertTrue(entries.contains("logback.xml"));
+  }
+
+  @Test
+  void executableArchiveKeepsBundledLoggingBehavior() throws IOException {
+    Set<String> entries = readEntries("pharmcat.shadowJar");
+
+    assertTrue(entries.contains("org/pharmgkb/pharmcat/PharmCAT.class"));
+    assertTrue(entries.contains("ch/qos/logback/classic/Logger.class"));
+    assertTrue(entries.contains("logback.xml"));
+  }
+
+  @Test
+  void noLogbackArchiveBundlesDependenciesWithoutLogback() throws IOException {
+    String property = "pharmcat.noLogbackJar";
+    Set<String> entries = readEntries(property);
+
+    assertTrue(archivePath(property).getFileName().toString().endsWith("-no-logback.jar"));
+    assertTrue(entries.contains("org/pharmgkb/pharmcat/PharmCAT.class"));
+    assertTrue(entries.contains("com/google/gson/Gson.class"));
+    assertTrue(entries.contains("org/slf4j/Logger.class"));
+    assertFalse(entries.stream().anyMatch(name -> name.startsWith("ch/qos/logback/")));
+    assertFalse(entries.contains("logback.xml"));
+
+    try (JarFile jarFile = new JarFile(archivePath(property).toFile())) {
+      assertEquals("org.pharmgkb.pharmcat.PharmCAT",
+          jarFile.getManifest().getMainAttributes().getValue("Main-Class"));
+    }
+  }
+
+  private static Set<String> readEntries(String property) throws IOException {
+    Path archive = archivePath(property);
+    try (JarFile jarFile = new JarFile(archive.toFile())) {
+      return jarFile.stream().map(entry -> entry.getName()).collect(Collectors.toSet());
+    }
+  }
+
+  private static Path archivePath(String property) {
+    return Path.of(System.getProperty(property));
+  }
+}


### PR DESCRIPTION
## Summary

- add a local `noLogbackJar` Gradle target that builds a runnable fat JAR while excluding `logback-classic`, `logback-core`, and `logback.xml`
- leave the existing thin JAR, `-all` JAR, and release workflow unchanged
- document that consumers of the new artifact must provide a compatible SLF4J provider and logging configuration
- add archive-level regression tests for all three packaging contracts

This follows the direction in #228: the new artifact is available as an explicit local build target and is not published as a release asset.

Addresses #228.

## Verification

- `./gradlew test --tests org.pharmgkb.pharmcat.DistributionArchiveTest --tests org.pharmgkb.pharmcat.util.CliUtilsTest --no-daemon --console=plain` — passed on Amazon Corretto 17 from a clean `build/` directory
- `java -jar build/libs/pharmcat-*-no-logback.jar -h` — passed with exit code 0 on Amazon Corretto 17
- direct archive inspection — the new JAR contains PharmCAT, Gson, and `slf4j-api`; it contains no `ch/qos/logback/` entries or `logback.xml`
- `CI=true GITHUB_ACTION=true GITHUB_EVENT_NAME=push ./gradlew clean test --no-daemon --console=plain` — full clean suite passed on JAIPilot Remote using Amazon Corretto 17; exact commit `da9d9f8b19d4d8a8ac94358e2deff14be50fc4a8`, exit code 0, 22m 28s command time, untruncated logs, and remote source deletion confirmed

## AI assistance

This change materially used [JAIPilot](https://github.com/JAIPilot/jaipilot) skills `jaipilot-maintainer-intent`, `jaipilot-generate-tests`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`. Host model: `gpt-5.6-sol`; reasoning effort: `xhigh`; host service mode: `fast`; execution mode: local host workflows plus private disposable exact-SHA JAIPilot Remote execution on AWS CodeBuild.
